### PR TITLE
chore: turn on os observability backend

### DIFF
--- a/chart/values.tmpl.yaml
+++ b/chart/values.tmpl.yaml
@@ -33,16 +33,3 @@ components:
         volumeMounts:
           - name: config-rw
             mountPath: /app/data
-
-# Disable Monitoring Infra components since we already have our own.
-# We use default.envOverrides to send telemetry to our own Observability stack.
-# opentelemetry-collector:
-#   enabled: false
-# jaeger:
-#   enabled: false
-# prometheus:
-#   enabled: false
-# grafana:
-#   enabled: false
-# opensearch:
-#   enabled: false

--- a/chart/values.tmpl.yaml
+++ b/chart/values.tmpl.yaml
@@ -7,7 +7,7 @@ components:
   flagd:
     resources:
       requests:
-        cpu : 100m
+        cpu: 100m
         memory: 128Mi
       limits:
         cpu: 1000m
@@ -36,13 +36,13 @@ components:
 
 # Disable Monitoring Infra components since we already have our own.
 # We use default.envOverrides to send telemetry to our own Observability stack.
-opentelemetry-collector:
-  enabled: false
-jaeger:
-  enabled: false
-prometheus:
-  enabled: false
-grafana:
-  enabled: false
-opensearch:
-  enabled: false
+# opentelemetry-collector:
+#   enabled: false
+# jaeger:
+#   enabled: false
+# prometheus:
+#   enabled: false
+# grafana:
+#   enabled: false
+# opensearch:
+#   enabled: false


### PR DESCRIPTION
We want to try out grafana, jaegar, etc.

@haq204 
I don't have sufficient k8 cluster permissions to deploy this. Can you redeploy this when you get the chance, thanks.